### PR TITLE
Add Hirber hook to all defined output methods

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
 source "https://rubygems.org"
 
 gemspec
+
+gem "pry"

--- a/lib/hirb/view.rb
+++ b/lib/hirb/view.rb
@@ -187,16 +187,18 @@ module Hirb
         if defined?(Ripl) && Ripl.respond_to?(:started?) && Ripl.started?
           @output_method = true
           require 'ripl/hirb' unless defined? Ripl::Hirb
+        end
 
-        elsif defined? Pry
+        if defined? Pry
           original_print = Pry.config.print
 
           Pry.config.print = proc do |output, result, pry_instance|
             Hirb::View.view_or_page_output(result) ||
               original_print.call(output, result, pry_instance)
           end
+        end
 
-        elsif defined?(IRB::Irb)
+        if defined?(IRB::Irb)
           @output_method = true
 
           ::IRB::Irb.class_eval do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -33,6 +33,8 @@ module ::IRB
   end
 end
 
+require "pry"
+
 RSpec.configure do |config|
   include RSpec::Helpers
 

--- a/spec/view_spec.rb
+++ b/spec/view_spec.rb
@@ -134,6 +134,16 @@ RSpec.describe "Hirb::View" do
       expect(Hirb::View.formatter.config.size).to be > 1
     end
 
+    it "sets up configuration for IRB and Pry if they're both defined" do
+      Hirb.disable
+      expect(Pry.config).to receive(:print=)
+      expect {
+        Hirb.enable
+      }.to change {
+        ::IRB::Irb.instance_method(:output_value) == ::IRB::Irb.instance_method(:non_hirb_view_output)
+      }.from(true).to(false)
+    end
+
     it "with config_file option adds to config_file" do
       Hirb.enable :config_file => "test_file"
 


### PR DESCRIPTION
This resolves issue https://github.com/hirber/hirber/issues/6.

I've tested these changes in my sample application, described in related the issue, and the view is displayed in both `IRB` and `Pry`. You can checkout the branch ([`rails_mini_app@test_hirber_hook_change`](https://github.com/maneyko/rails_mini_app/compare/test_hirber_hook_change)) and verify the changes:

```ruby
[001]: MyTestModel.all
+----+--------------------------+-------+------+-------+--------+------------+
| id | a                        | b     | c    | d     | e      | f          |
+----+--------------------------+-------+------+-------+--------+------------+
| 1  | b26d43d26a37a53d0fc8068c | false | 9265 | 39.75 | 9225.0 | 0.00040733 |
| 2  | b76fd0fd94d8e3b27527526f | true  | 2868 | 3.06  | 4834.0 | 0.00048239 |
| 3  | e418cf15b0ec4051a9b4ef7b | true  | 1161 | 91.66 | 268.0  | 0.00017277 |
| 4  | 3b2a6901ea4819f2750d6a8d | false | 213  | 30.37 | 5437.0 | 0.00039324 |
| 5  | 9f9f76c272f8108c9ea57a8f | false | 5325 | 5.0   | 2635.0 | 0.00180505 |
| 6  | e21391e8853026629e7ebc56 | true  | 1442 | 42.07 | 7458.0 | 0.00028417 |
| 7  | 86723902eb12effe1377ef69 | true  | 9936 | 1.25  | 8568.0 | 0.00037821 |
| 8  | b3a3cfdf917fb944a25a4574 | false | 118  | 98.62 | 9717.0 | 0.00016116 |
| 9  | e575896618d064a06897b8e4 | false | 3826 | 10.12 | 7549.0 | 0.00013803 |
| 10 | a4f2615aea9aa511887a1fc3 | true  | 9608 | 25.09 | 5866.0 | 0.00010906 |
+----+--------------------------+-------+------+-------+--------+------------+
10 rows in set
[002]: binding.pry
[1] pry(main)> MyTestModel.all
+----+--------------------------+-------+------+-------+--------+------------+
| id | a                        | b     | c    | d     | e      | f          |
+----+--------------------------+-------+------+-------+--------+------------+
| 1  | b26d43d26a37a53d0fc8068c | false | 9265 | 39.75 | 9225.0 | 0.00040733 |
| 2  | b76fd0fd94d8e3b27527526f | true  | 2868 | 3.06  | 4834.0 | 0.00048239 |
| 3  | e418cf15b0ec4051a9b4ef7b | true  | 1161 | 91.66 | 268.0  | 0.00017277 |
| 4  | 3b2a6901ea4819f2750d6a8d | false | 213  | 30.37 | 5437.0 | 0.00039324 |
| 5  | 9f9f76c272f8108c9ea57a8f | false | 5325 | 5.0   | 2635.0 | 0.00180505 |
| 6  | e21391e8853026629e7ebc56 | true  | 1442 | 42.07 | 7458.0 | 0.00028417 |
| 7  | 86723902eb12effe1377ef69 | true  | 9936 | 1.25  | 8568.0 | 0.00037821 |
| 8  | b3a3cfdf917fb944a25a4574 | false | 118  | 98.62 | 9717.0 | 0.00016116 |
| 9  | e575896618d064a06897b8e4 | false | 3826 | 10.12 | 7549.0 | 0.00013803 |
| 10 | a4f2615aea9aa511887a1fc3 | true  | 9608 | 25.09 | 5866.0 | 0.00010906 |
+----+--------------------------+-------+------+-------+--------+------------+
```